### PR TITLE
Fix for missing style.css

### DIFF
--- a/hcaptcha.php
+++ b/hcaptcha.php
@@ -80,7 +80,7 @@ function hcap_captcha_script()
 {
     global $hcap_language;
     $dir = plugin_dir_url(__FILE__);
-    wp_enqueue_style('hcaptcha-style', $dir . 'assets/styles.css', [], false, 'all');
+    wp_enqueue_style('hcaptcha-style', $dir . 'style.css', [], false, 'all');
     wp_enqueue_script('hcaptcha-script', '//hcaptcha.com/1/api.js?hl=' . $hcap_language, array(), false, true);
 }
 

--- a/style.css
+++ b/style.css
@@ -1,0 +1,3 @@
+.h-captcha {
+  margin-bottom: 2rem;
+}


### PR DESCRIPTION
Relocate /assets/styles.css to /style.css as not being deployed properly and update hcaptcha.php accordingly. Tested working by manually placing / replacing the affected files.

Fixes https://github.com/hCaptcha/hcaptcha-wordpress-plugin/issues/22

/deploy/deploy.sh has not been modified, and I don't believe it needs to be just to support this change. But be aware whatever issues exist with deploy.sh they'll need to be addressed separately. I have not tested (and am unable to test due to lack of access) an end-to-end deploy into WordPress SVN using it.