### PR TITLE
Fix text domain.

### DIFF
--- a/backend/settings.php
+++ b/backend/settings.php
@@ -46,19 +46,19 @@ function hcap_display_options_page() {
 			?>
 			<div id="message" class="updated fade">
 				<p>
-					<?php esc_html_e( 'Settings Updated', 'hcaptcha-wp' ); ?>
+					<?php esc_html_e( 'Settings Updated', 'hcaptcha-for-forms-and-more' ); ?>
 				</p>
 			</div>
 			<?php
 		}
 		?>
-		<h3><?php esc_html_e( 'hCaptcha Settings', 'hcaptcha-wp' ); ?></h3>
+		<h3><?php esc_html_e( 'hCaptcha Settings', 'hcaptcha-for-forms-and-more' ); ?></h3>
 		<h3>
 			<?php
 			echo wp_kses_post(
 				__(
 					'In order to use <a href="https://hCaptcha.com/?r=wp" target="_blank">hCaptcha</a> please register <a href="https://hCaptcha.com/?r=wp" target="_blank">here</a> to get your site key and secret key.',
-					'hcaptcha-wp'
+					'hcaptcha-for-forms-and-more'
 				)
 			);
 			?>
@@ -68,7 +68,7 @@ function hcap_display_options_page() {
 			<p>
 				<input
 						type="submit"
-						value="<?php esc_html_e( 'Save hCaptcha Settings', 'hcaptcha-wp' ); ?>"
+						value="<?php esc_html_e( 'Save hCaptcha Settings', 'hcaptcha-for-forms-and-more' ); ?>"
 						class="button button-primary"
 						name="submit"/>
 			</p>
@@ -96,7 +96,7 @@ function hcap_display_options() {
 	);
 
 	?>
-	<strong><?php esc_html_e( 'Enable/Disable Features', 'hcaptcha-wp' ); ?></strong>
+	<strong><?php esc_html_e( 'Enable/Disable Features', 'hcaptcha-for-forms-and-more' ); ?></strong>
 	<br><br>
 	<?php
 

--- a/cf7/hcaptcha-cf7.php
+++ b/cf7/hcaptcha-cf7.php
@@ -137,7 +137,7 @@ function hcap_cf7_verify_recaptcha( $result ) {
 				'type' => 'captcha',
 				'name' => 'hcap_cf7-h-captcha-invalid',
 			],
-			__( 'Please complete the captcha.', 'hcaptcha-wp' )
+			__( 'Please complete the captcha.', 'hcaptcha-for-forms-and-more' )
 		);
 	} else {
 		$captcha_result = hcaptcha_request_verify( $data['h-captcha-response'] );
@@ -147,7 +147,7 @@ function hcap_cf7_verify_recaptcha( $result ) {
 					'type' => 'captcha',
 					'name' => 'hcap_cf7-h-captcha-invalid',
 				],
-				__( 'The Captcha is invalid.', 'hcaptcha-wp' )
+				__( 'The Captcha is invalid.', 'hcaptcha-for-forms-and-more' )
 			);
 		}
 	}

--- a/common/functions.php
+++ b/common/functions.php
@@ -54,115 +54,115 @@ add_shortcode( 'hcaptcha', 'hcap_shortcode' );
 function hcap_options() {
 	return [
 		'hcaptcha_api_key'                  => [
-			'label' => __( 'hCaptcha Site Key', 'hcaptcha-wp' ),
+			'label' => __( 'hCaptcha Site Key', 'hcaptcha-for-forms-and-more' ),
 			'type'  => 'text',
 		],
 		'hcaptcha_secret_key'               => [
-			'label' => __( 'hCaptcha Secret Key', 'hcaptcha-wp' ),
+			'label' => __( 'hCaptcha Secret Key', 'hcaptcha-for-forms-and-more' ),
 			'type'  => 'password',
 		],
 		'hcaptcha_theme'                    => [
-			'label'   => __( 'hCaptcha Theme', 'hcaptcha-wp' ),
+			'label'   => __( 'hCaptcha Theme', 'hcaptcha-for-forms-and-more' ),
 			'type'    => 'select',
 			'options' => [
-				'light' => __( 'Light', 'hcaptcha-wp' ),
-				'dark'  => __( 'Dark', 'hcaptcha-wp' ),
+				'light' => __( 'Light', 'hcaptcha-for-forms-and-more' ),
+				'dark'  => __( 'Dark', 'hcaptcha-for-forms-and-more' ),
 			],
 		],
 		'hcaptcha_size'                     => [
-			'label'   => __( 'hCaptcha Size', 'hcaptcha-wp' ),
+			'label'   => __( 'hCaptcha Size', 'hcaptcha-for-forms-and-more' ),
 			'type'    => 'select',
 			'options' => [
-				'normal'  => __( 'Normal', 'hcaptcha-wp' ),
-				'compact' => __( 'Compact', 'hcaptcha-wp' ),
+				'normal'  => __( 'Normal', 'hcaptcha-for-forms-and-more' ),
+				'compact' => __( 'Compact', 'hcaptcha-for-forms-and-more' ),
 			],
 		],
 		'hcaptcha_language'                 => [
-			'label'       => __( 'Override Language Detection (optional)', 'hcaptcha-wp' ),
+			'label'       => __( 'Override Language Detection (optional)', 'hcaptcha-for-forms-and-more' ),
 			'type'        => 'text',
 			'description' => __(
 				'Info on <a href="https://hcaptcha.com/docs/languages" target="_blank">language codes</a>.',
-				'hcaptcha-wp'
+				'hcaptcha-for-forms-and-more'
 			),
 		],
 		'hcaptcha_nf_status'                => [
-			'label' => __( 'Enable Ninja Forms Addon', 'hcaptcha-wp' ),
+			'label' => __( 'Enable Ninja Forms Addon', 'hcaptcha-for-forms-and-more' ),
 			'type'  => 'checkbox',
 		],
 		'hcaptcha_cf7_status'               => [
-			'label' => __( 'Enable Contact Form 7 Addon', 'hcaptcha-wp' ),
+			'label' => __( 'Enable Contact Form 7 Addon', 'hcaptcha-for-forms-and-more' ),
 			'type'  => 'checkbox',
 		],
 		'hcaptcha_lf_status'                => [
-			'label' => __( 'Enable hCaptcha on Login Form', 'hcaptcha-wp' ),
+			'label' => __( 'Enable hCaptcha on Login Form', 'hcaptcha-for-forms-and-more' ),
 			'type'  => 'checkbox',
 		],
 		'hcaptcha_rf_status'                => [
-			'label' => __( 'Enable hCaptcha on Register Form', 'hcaptcha-wp' ),
+			'label' => __( 'Enable hCaptcha on Register Form', 'hcaptcha-for-forms-and-more' ),
 			'type'  => 'checkbox',
 		],
 		'hcaptcha_cmf_status'               => [
-			'label' => __( 'Enable hCaptcha on Comment Form', 'hcaptcha-wp' ),
+			'label' => __( 'Enable hCaptcha on Comment Form', 'hcaptcha-for-forms-and-more' ),
 			'type'  => 'checkbox',
 		],
 		'hcaptcha_lpf_status'               => [
-			'label' => __( 'Enable hCaptcha on Lost Password Form', 'hcaptcha-wp' ),
+			'label' => __( 'Enable hCaptcha on Lost Password Form', 'hcaptcha-for-forms-and-more' ),
 			'type'  => 'checkbox',
 		],
 		'hcaptcha_wc_login_status'          => [
-			'label' => __( 'Enable hCaptcha on WooCommerce Login Form', 'hcaptcha-wp' ),
+			'label' => __( 'Enable hCaptcha on WooCommerce Login Form', 'hcaptcha-for-forms-and-more' ),
 			'type'  => 'checkbox',
 		],
 		'hcaptcha_wc_reg_status'            => [
-			'label' => __( 'Enable hCaptcha on WooCommerce Registration Form', 'hcaptcha-wp' ),
+			'label' => __( 'Enable hCaptcha on WooCommerce Registration Form', 'hcaptcha-for-forms-and-more' ),
 			'type'  => 'checkbox',
 		],
 		'hcaptcha_wc_lost_pass_status'      => [
-			'label' => __( 'Enable hCaptcha on WooCommerce Lost Password Form', 'hcaptcha-wp' ),
+			'label' => __( 'Enable hCaptcha on WooCommerce Lost Password Form', 'hcaptcha-for-forms-and-more' ),
 			'type'  => 'checkbox',
 		],
 		'hcaptcha_wc_checkout_status'       => [
-			'label' => __( 'Enable hCaptcha on WooCommerce Checkout Form', 'hcaptcha-wp' ),
+			'label' => __( 'Enable hCaptcha on WooCommerce Checkout Form', 'hcaptcha-for-forms-and-more' ),
 			'type'  => 'checkbox',
 		],
 		'hcaptcha_bp_reg_status'            => [
-			'label' => __( 'Enable hCaptcha on Buddypress Registration Form', 'hcaptcha-wp' ),
+			'label' => __( 'Enable hCaptcha on Buddypress Registration Form', 'hcaptcha-for-forms-and-more' ),
 			'type'  => 'checkbox',
 		],
 		'hcaptcha_bp_create_group_status'   => [
-			'label' => __( 'Enable hCaptcha on BuddyPress Create Group Form', 'hcaptcha-wp' ),
+			'label' => __( 'Enable hCaptcha on BuddyPress Create Group Form', 'hcaptcha-for-forms-and-more' ),
 			'type'  => 'checkbox',
 		],
 		'hcaptcha_bbp_new_topic_status'     => [
-			'label' => __( 'Enable hCaptcha on bbPress New Topic Form', 'hcaptcha-wp' ),
+			'label' => __( 'Enable hCaptcha on bbPress New Topic Form', 'hcaptcha-for-forms-and-more' ),
 			'type'  => 'checkbox',
 		],
 		'hcaptcha_bbp_reply_status'         => [
-			'label' => __( 'Enable hCaptcha on bbPress Reply Form', 'hcaptcha-wp' ),
+			'label' => __( 'Enable hCaptcha on bbPress Reply Form', 'hcaptcha-for-forms-and-more' ),
 			'type'  => 'checkbox',
 		],
 		'hcaptcha_wpforo_new_topic_status'  => [
-			'label' => __( 'Enable hCaptcha on WPForo New Topic Form', 'hcaptcha-wp' ),
+			'label' => __( 'Enable hCaptcha on WPForo New Topic Form', 'hcaptcha-for-forms-and-more' ),
 			'type'  => 'checkbox',
 		],
 		'hcaptcha_wpforo_reply_status'      => [
-			'label' => __( 'Enable hCaptcha on WPForo Reply Form', 'hcaptcha-wp' ),
+			'label' => __( 'Enable hCaptcha on WPForo Reply Form', 'hcaptcha-for-forms-and-more' ),
 			'type'  => 'checkbox',
 		],
 		'hcaptcha_mc4wp_status'             => [
-			'label' => __( 'Enable hCaptcha on Mailchimp for WP Form', 'hcaptcha-wp' ),
+			'label' => __( 'Enable hCaptcha on Mailchimp for WP Form', 'hcaptcha-for-forms-and-more' ),
 			'type'  => 'checkbox',
 		],
 		'hcaptcha_jetpack_cf_status'        => [
-			'label' => __( 'Enable hCaptcha on Jetpack Contact Form', 'hcaptcha-wp' ),
+			'label' => __( 'Enable hCaptcha on Jetpack Contact Form', 'hcaptcha-for-forms-and-more' ),
 			'type'  => 'checkbox',
 		],
 		'hcaptcha_subscribers_status'       => [
-			'label' => __( 'Enable hCaptcha on Subscribers Form', 'hcaptcha-wp' ),
+			'label' => __( 'Enable hCaptcha on Subscribers Form', 'hcaptcha-for-forms-and-more' ),
 			'type'  => 'checkbox',
 		],
 		'hcaptcha_wc_wl_create_list_status' => [
-			'label' => __( 'Enable hCaptcha on WooCommerce Wishlists Create List Form', 'hcaptcha-wp' ),
+			'label' => __( 'Enable hCaptcha on WooCommerce Wishlists Create List Form', 'hcaptcha-for-forms-and-more' ),
 			'type'  => 'checkbox',
 		],
 	];

--- a/common/request.php
+++ b/common/request.php
@@ -106,8 +106,8 @@ if ( ! function_exists( 'hcaptcha_get_verify_message' ) ) {
 	 */
 	function hcaptcha_get_verify_message( $nonce_field_name, $nonce_action_name ) {
 		return hcaptcha_get_verify_output(
-			__( 'Please complete the captcha.', 'hcaptcha-wp' ),
-			__( 'The Captcha is invalid.', 'hcaptcha-wp' ),
+			__( 'Please complete the captcha.', 'hcaptcha-for-forms-and-more' ),
+			__( 'The Captcha is invalid.', 'hcaptcha-for-forms-and-more' ),
 			$nonce_field_name,
 			$nonce_action_name
 		);
@@ -125,8 +125,8 @@ if ( ! function_exists( 'hcaptcha_get_verify_message_html' ) ) {
 	 */
 	function hcaptcha_get_verify_message_html( $nonce_field_name, $nonce_action_name ) {
 		return hcaptcha_get_verify_output(
-			__( '<strong>Error</strong>: Please complete the captcha.', 'hcaptcha-wp' ),
-			__( '<strong>Error</strong>: The Captcha is invalid.', 'hcaptcha-wp' ),
+			__( '<strong>Error</strong>: Please complete the captcha.', 'hcaptcha-for-forms-and-more' ),
+			__( '<strong>Error</strong>: The Captcha is invalid.', 'hcaptcha-for-forms-and-more' ),
 			$nonce_field_name,
 			$nonce_action_name
 		);

--- a/hcaptcha.php
+++ b/hcaptcha.php
@@ -13,8 +13,8 @@
  * WC requires at least: 3.0
  * WC tested up to: 4.2
  *
- * Text Domain: hcaptcha-wp
- * Domain Path: /languages/
+ * Text Domain: hcaptcha-for-forms-and-more
+ * Domain Path: /languages
  *
  * @package hcaptcha-wp
  * @author  hCaptcha
@@ -75,7 +75,7 @@ if ( ! function_exists( 'hcap_hcaptcha_error_message' ) ) {
 	 * @return string
 	 */
 	function hcap_hcaptcha_error_message( $hcaptcha_content = '' ) {
-		$hcaptcha_content = sprintf( '<p id="hcap_error" class="error hcap_error">%s</p>', __( 'The Captcha is invalid.', 'hcaptcha-wp' ) ) . $hcaptcha_content;
+		$hcaptcha_content = sprintf( '<p id="hcap_error" class="error hcap_error">%s</p>', __( 'The Captcha is invalid.', 'hcaptcha-for-forms-and-more' ) ) . $hcaptcha_content;
 
 		return $hcaptcha_content;
 	}
@@ -214,7 +214,11 @@ add_action( 'plugins_loaded', 'hcap_load_modules', - PHP_INT_MAX );
  * Load plugin text domain.
  */
 function hcaptcha_wp_load_textdomain() {
-	load_plugin_textdomain( 'hcaptcha-wp', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
+	load_plugin_textdomain(
+		'hcaptcha-for-forms-and-more',
+		false,
+		dirname( plugin_basename( __FILE__ ) ) . '/languages/'
+	);
 }
 
 add_action( 'plugins_loaded', 'hcaptcha_wp_load_textdomain' );

--- a/mailchimp/mailchimp-for-wp.php
+++ b/mailchimp/mailchimp-for-wp.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function hcap_add_mc4wp_error_message( $messages ) {
 	$messages['invalid_hcaptcha'] = [
 		'type' => 'error',
-		'text' => __( 'The Captcha is invalid.', 'hcaptcha-wp' ),
+		'text' => __( 'The Captcha is invalid.', 'hcaptcha-for-forms-and-more' ),
 	];
 
 	return $messages;

--- a/nf/class-nf-hcaptcha.php
+++ b/nf/class-nf-hcaptcha.php
@@ -86,12 +86,12 @@ class HCaptchaFieldsForNF extends NF_Fields_recaptcha {
 	 */
 	public function validate( $field, $data ) {
 		if ( empty( $field['value'] ) ) {
-			return __( 'Please complete the captcha.', 'hcaptcha-wp' );
+			return __( 'Please complete the captcha.', 'hcaptcha-for-forms-and-more' );
 		}
 
 		$result = hcaptcha_request_verify( $field['value'] );
 		if ( 'fail' === $result ) {
-			return [ __( 'The Captcha is invalid.', 'hcaptcha-wp' ) ];
+			return [ __( 'The Captcha is invalid.', 'hcaptcha-for-forms-and-more' ) ];
 		}
 
 	}


### PR DESCRIPTION
According to the https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/, text domain must be the same as plugin slug on wp.org: hcaptcha-for-forms-and-more.

Otherwise, GlotPress translation does not work: https://translate.wordpress.org/projects/wp-plugins/hcaptcha-for-forms-and-more/