### PR TITLE
New option for Settings page for 'recaptchacompat'

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,15 @@ See our blog post at: https://medium.com/hcaptcha-blog/hcaptcha-plugin-for-wordp
 * Mailchimp for WP Form
 * Jetpack Contact Form
 * Subscribers Form
+
+**Please note**
+
+Some plugins listed have been superceded by native support, and are included only for legacy purposes.
+
+You should always use native hCaptcha support if available for your plugin.
+Please check with your plugin author if native support is not yet available.
+
+Instructions for native integrations are below:
+
+* [WPForms native integration: instructions to enable hCaptcha](https://wpforms.com/docs/how-to-set-up-and-use-hcaptcha-in-wpforms/)
+

--- a/common/functions.php
+++ b/common/functions.php
@@ -85,9 +85,9 @@ function hcap_options() {
 				'hcaptcha-for-forms-and-more'
 			),
 		),
-        'hcaptcha_recaptchacompat'          => array(
-			'label'     => __( 'Disable recaptchacompat (stop replacing other instances of reCaptcha with hCaptcha)', 'hcaptcha-for-forms-and-more' ),
-			'type'      => 'checkbox',
+		'hcaptcha_recaptchacompat'          => array(
+			'label' => __( 'Disable recaptchacompat (stop replacing other instances of reCaptcha with hCaptcha)', 'hcaptcha-for-forms-and-more' ),
+			'type'  => 'checkbox',
 		),
 		'hcaptcha_nf_status'                => array(
 			'label' => __( 'Enable Ninja Forms Addon', 'hcaptcha-for-forms-and-more' ),

--- a/common/functions.php
+++ b/common/functions.php
@@ -86,7 +86,7 @@ function hcap_options() {
 			),
 		),
 		'hcaptcha_recaptchacompat'          => array(
-			'label' => __( 'Disable recaptchacompat (stop replacing other instances of reCaptcha with hCaptcha)', 'hcaptcha-for-forms-and-more' ),
+			'label' => __( 'Disable recaptchacompat (stop replacing other instances of reCAPTCHA with hCaptcha)', 'hcaptcha-for-forms-and-more' ),
 			'type'  => 'checkbox',
 		),
 		'hcaptcha_nf_status'                => array(

--- a/common/functions.php
+++ b/common/functions.php
@@ -85,6 +85,10 @@ function hcap_options() {
 				'hcaptcha-for-forms-and-more'
 			),
 		),
+        'hcaptcha_recaptchacompat'          => array(
+			'label'     => __( 'Disable recaptchacompat (stop replacing other instances of reCaptcha with hCaptcha)', 'hcaptcha-for-forms-and-more' ),
+			'type'      => 'checkbox',
+		),
 		'hcaptcha_nf_status'                => array(
 			'label' => __( 'Enable Ninja Forms Addon', 'hcaptcha-for-forms-and-more' ),
 			'type'  => 'checkbox',

--- a/hcaptcha.php
+++ b/hcaptcha.php
@@ -57,11 +57,12 @@ if ( is_admin() ) {
  * Add the hcaptcha script to footer.
  */
 function hcap_captcha_script() {
+    if( get_option( 'hcaptcha_recaptchacompat' ) ) { $compat = '&recaptchacompat=off'; }
 	$dir = plugin_dir_url( __FILE__ );
 	wp_enqueue_style( 'hcaptcha-style', $dir . '/css/style.css', array(), HCAPTCHA_VERSION );
 	wp_enqueue_script(
 		'hcaptcha-script',
-		'//hcaptcha.com/1/api.js?hl=' . get_option( 'hcaptcha_language' ),
+		'//hcaptcha.com/1/api.js?hl=' . get_option( 'hcaptcha_language' ) . $compat,
 		array(),
 		HCAPTCHA_VERSION,
 		true

--- a/hcaptcha.php
+++ b/hcaptcha.php
@@ -61,21 +61,17 @@ function hcap_captcha_script() {
 	if ( get_option( 'hcaptcha_recaptchacompat' ) || get_option( 'hcaptcha_language' ) ) {
 		$url_params = '?';
 
-		if ( get_option( 'hcaptcha_recaptchacompat' ) && get_option( 'hcaptcha_language' ) ) {
-			$param_separator = '&';
-		} else {
-			$param_separator = '';
+		$param_array = array();
+
+		if ( get_option( 'hcaptcha_recaptchacompat' ) ) {
+			$param_array['recaptchacompat'] = 'off';
 		}
 
 		if ( get_option( 'hcaptcha_language' ) ) {
-			$url_params .= 'hl=' . get_option( 'hcaptcha_language' );
+			$param_array['hl'] = get_option( 'hcaptcha_language' );
 		}
 
-		$url_params .= $param_separator;
-
-		if ( get_option( 'hcaptcha_recaptchacompat' ) ) {
-			$url_params .= 'recaptchacompat=off';
-		}
+		$url_params .= http_build_query( $param_array );
 	}
 
 	$dir = plugin_dir_url( __FILE__ );

--- a/hcaptcha.php
+++ b/hcaptcha.php
@@ -76,7 +76,6 @@ function hcap_captcha_script() {
 		if ( get_option( 'hcaptcha_recaptchacompat' ) ) {
 			$url_params .= 'recaptchacompat=off';
 		}
-
 	}
 
 	$dir = plugin_dir_url( __FILE__ );

--- a/hcaptcha.php
+++ b/hcaptcha.php
@@ -57,15 +57,33 @@ if ( is_admin() ) {
  * Add the hcaptcha script to footer.
  */
 function hcap_captcha_script() {
-	if ( get_option( 'hcaptcha_recaptchacompat' ) ) {
-		$compat = '&recaptchacompat=off';
+	$url_params = '';
+	if ( get_option( 'hcaptcha_recaptchacompat' ) || get_option( 'hcaptcha_language' ) ) {
+		$url_params = '?';
+
+		if ( get_option( 'hcaptcha_recaptchacompat' ) && get_option( 'hcaptcha_language' ) ) {
+			$param_separator = '&';
+		} else {
+			$param_separator = '';
+		}
+
+		if ( get_option( 'hcaptcha_language' ) ) {
+			$url_params .= 'hl=' . get_option( 'hcaptcha_language' );
+		}
+
+		$url_params .= $param_separator;
+
+		if ( get_option( 'hcaptcha_recaptchacompat' ) ) {
+			$url_params .= 'recaptchacompat=off';
+		}
+
 	}
 
 	$dir = plugin_dir_url( __FILE__ );
 	wp_enqueue_style( 'hcaptcha-style', $dir . '/css/style.css', array(), HCAPTCHA_VERSION );
 	wp_enqueue_script(
 		'hcaptcha-script',
-		'//hcaptcha.com/1/api.js?hl=' . get_option( 'hcaptcha_language' ) . $compat,
+		'//hcaptcha.com/1/api.js' . $url_params,
 		array(),
 		HCAPTCHA_VERSION,
 		true

--- a/hcaptcha.php
+++ b/hcaptcha.php
@@ -57,7 +57,10 @@ if ( is_admin() ) {
  * Add the hcaptcha script to footer.
  */
 function hcap_captcha_script() {
-    if( get_option( 'hcaptcha_recaptchacompat' ) ) { $compat = '&recaptchacompat=off'; }
+	if ( get_option( 'hcaptcha_recaptchacompat' ) ) {
+		$compat = '&recaptchacompat=off';
+	}
+
 	$dir = plugin_dir_url( __FILE__ );
 	wp_enqueue_style( 'hcaptcha-style', $dir . '/css/style.css', array(), HCAPTCHA_VERSION );
 	wp_enqueue_script(

--- a/readme.txt
+++ b/readme.txt
@@ -145,3 +145,14 @@ Please see the hCaptcha privacy policy at:
 * Jetpack Contact Form
 * Subscribers Form
 
+=== Please note ===
+
+Some plugins listed have been superceded by native support, and are included only for legacy purposes.
+
+You should always use native hCaptcha support if available for your plugin.
+Please check with your plugin author if native support is not yet available.
+
+Instructions for native integrations are below:
+
+* [WPForms native integration: instructions to enable hCaptcha](https://wpforms.com/docs/how-to-set-up-and-use-hcaptcha-in-wpforms)
+


### PR DESCRIPTION
Allows adding a URL parameter to stop the (by default) replacement of reCaptcha outside of the plugin's included module.
https://docs.hcaptcha.com/configuration

**Use case:** I have sites that include a Constant Contact signup widget in/around the footer, and they include reCaptcha v3 invisible by default with no way to manage the sitekey or secret. Adding this option and enabling it on these sites allows both types of captcha to work properly, even on the same page.

Edit: I'm not sure how the update docs commit got wrapped up in here, that was unintentional.