### PR TITLE
Allow button tag for submit

### DIFF
--- a/src/php/CF7/CF7.php
+++ b/src/php/CF7/CF7.php
@@ -51,7 +51,7 @@ class CF7 {
 		}
 
 		$cf7_hcap_form = do_shortcode( '[' . self::SHORTCODE . ']' );
-		$submit_button = '/(<input .*?type="submit")/';
+		$submit_button = '/(<(input|button) .*?type="submit")/';
 
 		return preg_replace(
 			$submit_button,


### PR DESCRIPTION
For CF7 if using a `<button>` for submitting the form, hcaptcha doesn't appear on the page and thus doesn't work