### PR TITLE
Fix hcaptcha-divi.js by adding a type guard

### DIFF
--- a/.tests/js/assets-js-files/hcaptcha-divi.test.js
+++ b/.tests/js/assets-js-files/hcaptcha-divi.test.js
@@ -27,4 +27,15 @@ describe( 'hCaptcha ajaxStop binding', () => {
 		$( document ).trigger( 'ajaxSuccess', [ xhr, settings ] );
 		expect( hCaptchaBindEvents ).toHaveBeenCalledTimes( 1 );
 	} );
+
+  test ('hCaptchaBindEvents is called when ajaxSuccess event is triggered with unexpected data', () => {
+    const xhr = {};
+    const settings = {};
+
+    // Unexpected object which does not have `.includes` method
+    settings.data = {};
+    $( document ).trigger( 'ajaxSuccess', [ xhr, settings ] );
+    expect( hCaptchaBindEvents ).toHaveBeenCalledTimes( 1 );
+  })
+
 } );

--- a/assets/js/hcaptcha-divi.js
+++ b/assets/js/hcaptcha-divi.js
@@ -1,10 +1,10 @@
 /* global jQuery */
 
 jQuery( document ).on( 'ajaxSuccess', function( event, xhr, settings ) {
-	if ( 
-        	typeof settings.data.includes === "function" &&
-             	! settings.data.includes( 'et_pb_contactform_submit_' )
-        ) {
+	if (
+		typeof settings.data.includes === 'function' &&
+		! settings.data.includes( 'et_pb_contactform_submit_' )
+	) {
 		return;
 	}
 

--- a/assets/js/hcaptcha-divi.js
+++ b/assets/js/hcaptcha-divi.js
@@ -1,7 +1,10 @@
 /* global jQuery */
 
 jQuery( document ).on( 'ajaxSuccess', function( event, xhr, settings ) {
-	if ( ! settings.data.includes( 'et_pb_contactform_submit_' ) ) {
+	if ( 
+        	typeof settings.data.includes === "function" &&
+             	! settings.data.includes( 'et_pb_contactform_submit_' )
+        ) {
 		return;
 	}
 


### PR DESCRIPTION
Adding a simple type guard to avoid reaching uncaught exceptions by calling `.includes` on a potentially any type of object.

⚠️ I am not 100% sure what is the idea of this function but it looks like it is trying to not attach hCaptcha events in certain cases. That brings me to the question if there are other cases where that condition should be triggered. E.g. file upload submissions. 

In other words, this PR only makes the code not crash, but has no impact on the current logic which might be missing some business cases.

**Related Issue:**
Related to https://github.com/hCaptcha/hcaptcha-wordpress-plugin/issues/325