### PR TITLE
Signup screen hCaptcha error message

### DIFF
--- a/src/php/WP/Signup.php
+++ b/src/php/WP/Signup.php
@@ -138,6 +138,6 @@ class Signup {
 			return '';
 		}
 
-		return '<p class="error" id="wp-signup-hcaptcha-error"><strong>Error:</strong>' . $this->error_message . '</p>';
+		return '<p class="error" id="wp-signup-hcaptcha-error">' . $this->error_message . '</p>';
 	}
 }


### PR DESCRIPTION
Signup screen hCaptcha error in line with WordPress errors on those screens (no "Error:" in front)