### PR TITLE
Harden PR CI checkout by disabling credential persistence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: ${{ env.wp-plugin-directory }}
+          persist-credentials: false
 
       # MOVED: The "Update changelog" step has been moved to the specific job below
       # to prevent giving 'contents: write' permissions to this testing job.


### PR DESCRIPTION
## Summary
- set `persist-credentials: false` on the checkout step in the `cs_and_tests` job of CI

## Why
This job runs on `pull_request` (for fork PRs). Disabling credential persistence hardens the runner environment by preventing accidental reuse of the token via local git config in subsequent steps.

## Scope
- no behavior changes to build/test logic
- only checkout credential handling is adjusted
